### PR TITLE
Multiple increments per click

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,18 @@ How to Use
 These are the constructor and the member functions the library provides:
 
 ```
-    ESPRotary(int pin1, int pin2);
+	// If you have an encoder which increments multiple times per click, adjust moves_per_click to a higher number
+    ESPRotary(int pin1, int pin2, int moves_per_click = 1);
 
     int getPosition();
+	int getMovesPerClick();
     void resetPosition();
     byte getDirection();
     String directionToString(byte direction);
     void setChangedHandler(CallbackFunction f);
     void setRightRotationHandler(CallbackFunction f);
     void setLeftRotationHandler(CallbackFunction f);
+	void setMovesPerClick();
 	
     void loop();
 ```

--- a/src/ESPRotary.cpp
+++ b/src/ESPRotary.cpp
@@ -14,6 +14,10 @@
 ESPRotary::ESPRotary(int pin1, int pin2, int moves_per_click ) {
   this->pin1 = pin1;
   this->pin2 = pin2;
+  if (moves_per_click < 1) {
+	#pragma message ("At least one move per click required, reverting to 1")
+	moves_per_click = 1;
+  }
   this->moves_per_click = moves_per_click;
 
   pinMode(pin1, INPUT_PULLUP);

--- a/src/ESPRotary.cpp
+++ b/src/ESPRotary.cpp
@@ -9,9 +9,12 @@
 
 /////////////////////////////////////////////////////////////////
 
-ESPRotary::ESPRotary(int pin1, int pin2) {
+
+
+ESPRotary::ESPRotary(int pin1, int pin2, int moves_per_click ) {
   this->pin1 = pin1;
   this->pin2 = pin2;
+  this->moves_per_click = moves_per_click;
 
   pinMode(pin1, INPUT_PULLUP);
   pinMode(pin2, INPUT_PULLUP);
@@ -66,7 +69,7 @@ String ESPRotary::directionToString(byte direction) {
 /////////////////////////////////////////////////////////////////
 
 int ESPRotary::getPosition() {
-  return position;
+  return position / moves_per_click;
 }
 
 /////////////////////////////////////////////////////////////////
@@ -91,15 +94,18 @@ void ESPRotary::loop() {
       state = (s >> 2);
   
       if (position != last_position) {
-        if (position > last_position) {
-          direction = RE_RIGHT;  
-          if (right_cb != NULL) right_cb (*this);    
-        } else {
-          direction = RE_LEFT;
-          if (left_cb != NULL) left_cb (*this);    
-        }
-        last_position = position;
-        if (change_cb != NULL) change_cb (*this);    
+		if (position - last_position >= moves_per_click || position - last_position <= -moves_per_click) {
+			if (position > last_position) {
+			  direction = RE_RIGHT;  
+			  if (right_cb != NULL) right_cb (*this);    
+			} else {
+			  direction = RE_LEFT;
+			  if (left_cb != NULL) left_cb (*this);    
+			}
+			last_position = position;
+
+			if (change_cb != NULL) change_cb (*this);    
+		}
       }
 }
 

--- a/src/ESPRotary.h
+++ b/src/ESPRotary.h
@@ -22,7 +22,7 @@
 
 class ESPRotary {
   private:
-    int pin1, pin2, position, last_position;
+    int pin1, pin2, position, last_position, moves_per_click;
     unsigned long last_read_ms;
     byte direction;
     byte state;
@@ -33,11 +33,15 @@ class ESPRotary {
     CallbackFunction left_cb = NULL;
     
   public:
-    ESPRotary(int pin1, int pin2);
+    ESPRotary(int pin1, int pin2, int moves_per_click = 1);
 
     int getPosition();
     void resetPosition();
     byte getDirection();
+	
+	inline int getMovePerClick() {return moves_per_click;}
+	inline int setMovesPerClick(int movesPerClick) {moves_per_click = movesPerClick;}
+	
     String directionToString(byte direction);
     void setChangedHandler(CallbackFunction f);
     void setRightRotationHandler(CallbackFunction f);

--- a/src/ESPRotary.h
+++ b/src/ESPRotary.h
@@ -40,7 +40,6 @@ class ESPRotary {
     byte getDirection();
 	
 	inline int getMovePerClick() {return moves_per_click;}
-	inline void setMovesPerClick(int movesPerClick) {moves_per_click = movesPerClick;}
 	
     String directionToString(byte direction);
     void setChangedHandler(CallbackFunction f);

--- a/src/ESPRotary.h
+++ b/src/ESPRotary.h
@@ -40,7 +40,7 @@ class ESPRotary {
     byte getDirection();
 	
 	inline int getMovePerClick() {return moves_per_click;}
-	inline int setMovesPerClick(int movesPerClick) {moves_per_click = movesPerClick;}
+	inline void setMovesPerClick(int movesPerClick) {moves_per_click = movesPerClick;}
 	
     String directionToString(byte direction);
     void setChangedHandler(CallbackFunction f);


### PR DESCRIPTION
Many cheap encoders report multiple increments per single click. This causes a single turn to fire multiple callbacks which is not very nice.
This pull request adds the option to set the number of increments per click.