### PR TITLE
Fix upper_bound overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Fixed upper_bound overflow preventing exemple to work on arduino Uno
 
 ## [1.4] - 2020-06-26
 
@@ -23,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [1.2.0] - 2020-04-20
-- Created and added CHANGELOG.md 
+- Created and added CHANGELOG.md
 - Added optional minimum and maximum bounds to constructor (as suggested by [cornfeedhobo](https://github.com/cornfeedhobo) in issue [#9](https://github.com/LennartHennigs/ESPRotary/issues/9))
 
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Description
 -----------
 
 It allows you to use callback functions to be notified when the rotary encoder position changes.
-This will reduce and simplify your source code significantly. Tested with Arduino and ESP8266. 
+This will reduce and simplify your source code significantly. Tested with Arduino and ESP8266.
 Some of the code based on the library by PJRC (https://www.pjrc.com/teensy/td_libs_Encoder.html).
 
 How to Use
@@ -23,11 +23,11 @@ These are the constructor and the member functions the library provides:
 ```
 // If you have an encoder which increments multiple times per click, adjust steps_per_click
     ESPRotary(
-        int pin1, 
-        int pin2, 
-        int steps_per_click = 1, 
-        int lower_bound = -32768, 
-        int upper_bound = 32768
+        int pin1,
+        int pin2,
+        int steps_per_click = 1,
+        int lower_bound = INT16_MIN,
+        int upper_bound = INT16_MAX
         );
 
     void setChangedHandler(CallbackFunction f);
@@ -53,7 +53,7 @@ The library provides several callback handlers to be notified when the rotary en
 
 Installation
 ------------
-Open the Arduino IDE choose "Sketch > Include Library" and search for "ESP Rotary". 
+Open the Arduino IDE choose "Sketch > Include Library" and search for "ESP Rotary".
 Or download the ZIP archive (https://github.com/lennarthennigs/ESPRotary/zipball/master), and choose "Sketch > Include Library > Add .ZIP Library..." and select the downloaded file.
 
 

--- a/src/ESPRotary.cpp
+++ b/src/ESPRotary.cpp
@@ -9,7 +9,7 @@
 
 /////////////////////////////////////////////////////////////////
 
-ESPRotary::ESPRotary(int pin1, int pin2, int steps_per_click /* = 1 */, int lower_bound /* = -32768 */, int upper_bound /* = 32768 */) {
+ESPRotary::ESPRotary(int pin1, int pin2, int steps_per_click /* = 1 */, int lower_bound /* = INT16_MIN */, int upper_bound /* = INT16_MAX */) {
   this->pin1 = pin1;
   this->pin2 = pin2;
   this->lower_bound = (lower_bound < upper_bound) ? lower_bound : upper_bound;
@@ -56,7 +56,7 @@ void ESPRotary::resetPosition(int p /* = 0 */) {
 
 /////////////////////////////////////////////////////////////////
 
-void ESPRotary::setStepsPerClick(int steps) {  
+void ESPRotary::setStepsPerClick(int steps) {
   steps_per_click = (steps < 1) ? 1 : steps;
 }
 
@@ -108,7 +108,7 @@ void ESPRotary::loop() {
       position -= 2; break;
   }
   state = (s >> 2);
-  
+
   if (getPosition() >= lower_bound && getPosition() <= upper_bound) {
     if (position != last_position) {
       if (abs(position - last_position) >= steps_per_click) {
@@ -119,7 +119,7 @@ void ESPRotary::loop() {
           direction = RE_LEFT;
           if (left_cb != NULL) left_cb (*this);
         }
-        last_position = position;      
+        last_position = position;
         if (change_cb != NULL) change_cb (*this);
       }
     }

--- a/src/ESPRotary.h
+++ b/src/ESPRotary.h
@@ -33,16 +33,16 @@ class ESPRotary {
     CallbackFunction left_cb = NULL;
 
  public:
-    ESPRotary(int pin1, int pin2, int steps_per_click = 1, int lower_bound = -32768, int upper_bound = 32768);
+    ESPRotary(int pin1, int pin2, int steps_per_click = 1, int lower_bound = INT16_MIN, int upper_bound = INT16_MAX);
 
     int getPosition();
     void resetPosition(int p = 0);
     byte getDirection();
-    
+
     void setStepsPerClick(int steps);
     int getStepsPerClick();
 
-    String directionToString(byte direction);    
+    String directionToString(byte direction);
     void setChangedHandler(CallbackFunction f);
     void setRightRotationHandler(CallbackFunction f);
     void setLeftRotationHandler(CallbackFunction f);


### PR DESCRIPTION
`upper_bound` is a 16-bits signed int so the default value of 32768 is an overflow and upper_bound real value is -32768, same as default `lower_bound` value, preventing `SimpleCounterWithButton` example to work (tested on arduino Uno).

See [Arduino documentation](https://www.arduino.cc/en/Reference.Int) for reference.

This pull request fixes that behaviour by using `INT16_MIN` and `INT16_MAX` constants for `lower_bound` and `upper_bound` respectively.