### PR TITLE
Avoid triggering change after resetPosition()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Avoid triggering change_cb after resetPosition to other position than 0
 
 ## [1.4] - 2020-06-26
 
@@ -23,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [1.2.0] - 2020-04-20
-- Created and added CHANGELOG.md 
+- Created and added CHANGELOG.md
 - Added optional minimum and maximum bounds to constructor (as suggested by [cornfeedhobo](https://github.com/cornfeedhobo) in issue [#9](https://github.com/LennartHennigs/ESPRotary/issues/9))
 
 

--- a/src/ESPRotary.cpp
+++ b/src/ESPRotary.cpp
@@ -48,15 +48,15 @@ void ESPRotary::resetPosition(int p /* = 0 */) {
   if (p > upper_bound) {
     last_position = upper_bound * steps_per_click;
   } else {
-    last_position = (lower_bound > p) ? lower_bound * steps_per_click : p;
+    last_position = (lower_bound > p) ? lower_bound * steps_per_click : p * steps_per_click;
   }
-  position = last_position * steps_per_click;
+  position = last_position;
   direction = 0;
 }
 
 /////////////////////////////////////////////////////////////////
 
-void ESPRotary::setStepsPerClick(int steps) {  
+void ESPRotary::setStepsPerClick(int steps) {
   steps_per_click = (steps < 1) ? 1 : steps;
 }
 
@@ -108,7 +108,7 @@ void ESPRotary::loop() {
       position -= 2; break;
   }
   state = (s >> 2);
-  
+
   if (getPosition() >= lower_bound && getPosition() <= upper_bound) {
     if (position != last_position) {
       if (abs(position - last_position) >= steps_per_click) {
@@ -119,7 +119,7 @@ void ESPRotary::loop() {
           direction = RE_LEFT;
           if (left_cb != NULL) left_cb (*this);
         }
-        last_position = position;      
+        last_position = position;
         if (change_cb != NULL) change_cb (*this);
       }
     }


### PR DESCRIPTION
Currently `resetPosition()` sets `position` and `last_position` to different values when the `p` parameter is not 0. This results on a change in the next step firing callbacks.

`resetPosition()` should set `position` and `last_position` to the same value to avoid unnecessary callback function call each time `resetPosition()` is called.

This PR fixes that behavviour by setting `last_position` and `position` to the same value