### PR TITLE
Fix extra condition

### DIFF
--- a/src/ESPRotary.cpp
+++ b/src/ESPRotary.cpp
@@ -81,9 +81,9 @@ byte ESPRotary::getDirection() {
 String ESPRotary::directionToString(byte direction) {
   if (direction == RE_LEFT) {
     return "LEFT";
-  } else (direction == RE_RIGHT) {
+  } else {
     return "RIGHT";
-    }
+  }
 }
 
 /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fix code error by removing an extra condition on an `else` statement introduced in https://github.com/LennartHennigs/ESPRotary/commit/fc1eff2039e89a62330c7183d6be159f429107cc