### PR TITLE
Allow to avoid resetPosition callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ These are the constructor and the member functions the library provides:
     void setLeftRotationHandler(CallbackFunction f);
 
     int getPosition();
-    void resetPosition(int p = 0);
+    void resetPosition(int p = 0, bool fireCallback = true);
 
     byte getDirection();
     String directionToString(byte direction);

--- a/src/ESPRotary.cpp
+++ b/src/ESPRotary.cpp
@@ -20,7 +20,7 @@ ESPRotary::ESPRotary(int pin1, int pin2, int steps_per_click /* = 1 */,  int ini
   pinMode(pin2, INPUT_PULLUP);
 
   loop();
-  resetPosition(inital_pos);
+  resetPosition(inital_pos, false);
   last_read_ms = 0;
 }
 
@@ -44,17 +44,17 @@ void ESPRotary::setLeftRotationHandler(CallbackFunction f) {
 
 /////////////////////////////////////////////////////////////////
 
-void ESPRotary::resetPosition(int p /* = 0 */) {
+void ESPRotary::resetPosition(int p /* = 0 */, bool fireCallback /* = true */) {
   if (p > upper_bound) {
     last_position = upper_bound * steps_per_click;
   } else {
     last_position = (lower_bound > p) ? lower_bound * steps_per_click : p * steps_per_click;
   }
 
-if (position != last_position) {
-  position = last_position;
-  if (change_cb != NULL) change_cb (*this);
-}
+  if (position != last_position) {
+    position = last_position;
+    if (fireCallback && change_cb != NULL) change_cb (*this);
+  }
   direction = 0;
 }
 

--- a/src/ESPRotary.h
+++ b/src/ESPRotary.h
@@ -36,7 +36,7 @@ class ESPRotary {
     ESPRotary(int pin1, int pin2, int steps_per_click = 1, int inital_pos = 0, int lower_bound = INT16_MIN, int upper_bound = INT16_MAX);
 
     int getPosition();
-    void resetPosition(int p = 0);
+    void resetPosition(int p = 0, bool fireCallback = true);
     byte getDirection();
 
     void setStepsPerClick(int steps);


### PR DESCRIPTION
I took time to understand why change callback was called when calling resetPosition and to fix that in #22.

Commit https://github.com/LennartHennigs/ESPRotary/commit/43f82bec34ed77596d61616b19e456b28b6d9cc2 does the exact opposite and adds an explicit callback when a call to `resetPosition()` result in a position "change".

I do think there are use-cases where you don't want a callback to fire when calling `resetPosition()`.

Calling resetPosition is a voluntary action. So if my sketch calls `resetPosition()`, I can also call whatever function that would have been called by the callback or use `getPosition()` to know if there was effectively a change.

On the other hand, there are use-cases where you do not want a callback when calling `resetPosition()` and you currently have no mean to know your callback function have been called from `resetPositon()` to cancel the callback. Think of correcting a difference between your knob "position" and the real world for example.

So this PR let you choose if you want a callback when calling `resetPosition()` by adding a new optional parameter that defaults to `true` (fire callback when positon changes) and can be set to `false` (don't fire callback if position changes).

It also ensures that `change_cb` callback will not be called by constructor when it calls resetPosition().