### PR TITLE
feat: add setContext/getContext for callback context (#48)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 .vscode
 *.code-workspace
+.pio
+/.pio/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.2.0] - 2026-07-27
+
+- Added `setContext(void*)` / `getContext()` to attach a custom context (typically a pointer to the object that owns the encoder) to an instance, retrievable inside callbacks via the passed `ESPRotary&`. This is the recommended way to give the plain-function callbacks access to custom state. Resolves [#48](https://github.com/LennartHennigs/ESPRotary/issues/48)
+- Added a `Context` example showing the owning-object pattern
+- Added a native test harness (PlatformIO + EpoxyDuino + AUnit) with a core-behavior suite and a context suite; see `platformio.ini` and `test/`
+
 ## [2.1.2] - 2026-05-09
 
 - Fixed parameterized constructor delegation — `ESPRotary(pin1, pin2, ...)` now correctly assigns an ID to `this` instead of a discarded temporary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-ESPRotary is an Arduino/ESP library (v2.1.1) for reading rotary encoder values via callback functions. It targets Arduino, ESP8266, and ESP32 devices and is distributed through the Arduino IDE Library Manager and PlatformIO.
+ESPRotary is an Arduino/ESP library (v2.2.0) for reading rotary encoder values via callback functions. It targets Arduino, ESP8266, and ESP32 devices and is distributed through the Arduino IDE Library Manager and PlatformIO.
 
 ## Architecture
 
@@ -24,9 +24,18 @@ The library is a single class (`ESPRotary`) split into two files:
 
 ## Development
 
-This is a header-only-style Arduino library — there is no build system or test runner. Development is done in the Arduino IDE or VS Code with the Arduino extension.
+Development is done in the Arduino IDE or VS Code with the Arduino extension.
 
 The `.vscode/arduino.json` is configured for an ESP8266 D1 Mini on `/dev/tty.usbserial-1410`. To verify/upload a sketch, open one of the examples and use the Arduino IDE or VS Code Arduino extension commands.
+
+**Native tests** run on the host via PlatformIO + EpoxyDuino + AUnit (no hardware needed), mirroring the sibling Button2 library:
+
+```
+pio test -e test_core      # core behavior (position, bounds, direction, speedup, IDs)
+pio test -e test_context   # setContext / getContext
+```
+
+Test sources live in `test/test_*/` with shared helpers in `test/shared/test_helpers.h`; env config is in `platformio.ini`. Note: PlatformIO reports "0 test cases" because it doesn't parse AUnit's output — a green (exit 0) run means the AUnit assertions passed; run `.pio/build/<env>/program` directly to see the per-test summary.
 
 **To test changes**, upload an example sketch to hardware:
 - `examples/SimpleCounter` — basic rotation and direction callbacks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ The library is a single class (`ESPRotary`) split into two files:
 - Speedup mode (`enableSpeedup`) increases the effective increment when turns happen faster than `speedup_interval` ms
 - `retriggerEvent(false)` suppresses repeated boundary events; `triggerOnBounds(false)` suppresses rotation callbacks when at a boundary
 - Each instance gets a static auto-incremented `id`
+- `setContext(void*)` / `getContext()` store an arbitrary pointer on the instance (usually the owning object) so the plain-function callbacks can recover custom state via the passed `ESPRotary&`
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,36 @@ Some of the code based of this library is based on code from [PJRC](https://www.
 - Alternatively, you can use `setID(int newID)` to set a new one. But then you need to make sure that they are unique.
 - You can also use the `==` operator to compare encoders
 
+### Context
+
+- The callback handlers are plain C function pointers, so they cannot capture surrounding state (no lambdas with captures).
+- To give a handler access to custom data — most commonly a pointer to the object that _owns_ the encoder — attach it as the encoder's context:
+  - `void setContext(void* ctx)` stores a `void*` on the encoder instance.
+  - `void* getContext() const` returns it.
+- Inside a handler you retrieve the context via the passed `ESPRotary&` and cast it back:
+
+``` c++
+class Dial {
+ public:
+  void begin(byte p1, byte p2) {
+    r.begin(p1, p2, 4);
+    r.setContext(this);                 // hand the encoder a pointer back to us
+    r.setChangedHandler(Dial::onRotate);
+  }
+  void loop() { r.loop(); }
+
+  static void onRotate(ESPRotary& sender) {
+    Dial* self = static_cast<Dial*>(sender.getContext());
+    self->handle(sender.getPosition());
+  }
+ private:
+  void handle(int pos) { /* ... */ }
+  ESPRotary r;
+};
+```
+
+- See the [Context](https://github.com/LennartHennigs/ESPRotary/blob/master/examples/Context/Context.ino) example.
+
 ## Notes
 
 - To see the latest changes to the library please take a look at the [Changelog](https://github.com/LennartHennigs/ESPRotary/blob/master/CHANGELOG.md).
@@ -121,6 +151,7 @@ Some of the code based of this library is based on code from [PJRC](https://www.
 - [SimpleCounterWithButton](https://github.com/LennartHennigs/ESPRotary/blob/master/examples/SimpleCounterWithButton/SimpleCounterWithButton.ino) - basic example with a button handler
 - [RangedCounter](https://github.com/LennartHennigs/ESPRotary/blob/master/examples/RangedCounter/RangedCounter.ino) - shows how to define ranges
 - [Speedup](https://github.com/LennartHennigs/ESPRotary/blob/master/examples/Speedup/Speedup.ino) - shows how to implement the speedup mode
+- [Context](https://github.com/LennartHennigs/ESPRotary/blob/master/examples/Context/Context.ino) - shows how to pass a context object to the callbacks
 - [ESP8266Interrupt](https://github.com/LennartHennigs/ESPRotary/blob/master/examples/ESP8266Interrupt/ESP8266Interrupt.ino) - uses an ESP8266 interrupt instead of the main loop
 - [ESP32Interrupt](https://github.com/LennartHennigs/ESPRotary/blob/master/examples/ESP32Interrupt/ESP32Interrupt.ino) - uses an ESP32 interrupt instead of the main loop
 
@@ -175,6 +206,9 @@ These are the constructor and the member functions the library provides:
 
   int getID() const;
   void setID(int newID);
+
+  void setContext(void* ctx);
+  void* getContext() const;
 
   bool operator == (ESPRotary &rhs);
 

--- a/examples/Context/Context.ino
+++ b/examples/Context/Context.ino
@@ -1,0 +1,74 @@
+/////////////////////////////////////////////////////////////////
+/*
+  Shows how to use setContext() / getContext() to route a global
+  callback back to the object that "owns" the encoder.
+
+  The callback functions are plain C functions (no captures), so we
+  attach a pointer to the owning object as the encoder's context and
+  recover it inside the handler via the passed ESPRotary reference.
+*/
+/////////////////////////////////////////////////////////////////
+
+#include "ESPRotary.h"
+
+/////////////////////////////////////////////////////////////////
+
+#define ROTARY_PIN1 D1
+#define ROTARY_PIN2 D2
+
+// this number depends on your rotary encoder
+#define CLICKS_PER_STEP 4
+
+#define SERIAL_SPEED 115200
+
+/////////////////////////////////////////////////////////////////
+
+// An object that owns a rotary encoder and reacts to its rotation.
+class Dial {
+ public:
+  Dial(const char* name) : name(name) {}
+
+  void begin(byte pin1, byte pin2) {
+    r.begin(pin1, pin2, CLICKS_PER_STEP);
+    // hand the encoder a pointer back to us...
+    r.setContext(this);
+    r.setChangedHandler(Dial::onRotate);
+  }
+
+  void loop() {
+    r.loop();
+  }
+
+  // static, so it matches the plain-function callback signature
+  static void onRotate(ESPRotary& sender) {
+    // ...and recover the owning Dial from the context
+    Dial* self = static_cast<Dial*>(sender.getContext());
+    Serial.print(self->name);
+    Serial.print(": ");
+    Serial.println(sender.getPosition());
+  }
+
+ private:
+  const char* name;
+  ESPRotary r;
+};
+
+/////////////////////////////////////////////////////////////////
+
+Dial volume("Volume");
+
+/////////////////////////////////////////////////////////////////
+
+void setup() {
+  Serial.begin(SERIAL_SPEED);
+  delay(50);
+  Serial.println("\n\nContext Example");
+
+  volume.begin(ROTARY_PIN1, ROTARY_PIN2);
+}
+
+void loop() {
+  volume.loop();
+}
+
+/////////////////////////////////////////////////////////////////

--- a/keywords.txt
+++ b/keywords.txt
@@ -30,5 +30,7 @@ retriggerEvent  KEYWORD2
 triggerOnBounds  KEYWORD2
 getID	KEYWORD2
 setID	KEYWORD2
+setContext	KEYWORD2
+getContext	KEYWORD2
 loop	KEYWORD2
 direction	LITERAL1

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
 	"name": "ESP Rotary",
-	"version": "2.1.2",
+	"version": "2.2.0",
 	"keywords": "rotary encoder, esp8266",
 	"description": "ESP8266/Arduino Library for reading rotary encoder values.",
 	"homepage": "https://github.com/LennartHennigs/ESPRotary",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP Rotary
-version=2.1.2
+version=2.2.0
 author=Lennart Hennigs
 maintainer=Lennart Hennigs <mail@lennarthennigs.de>
 sentence=ESP8266/Arduino Library for reading rotary encoder values.

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,60 @@
+; PlatformIO Project Configuration File
+;
+; Build options: build flags, source filter
+; Upload options: custom upload port, speed and extra flags
+; Library options: dependencies, extra library storages
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+; Hardware environment (upload to a real board)
+[env:Wemos_D1_Mini]
+platform = espressif8266
+board = d1_mini
+framework = arduino
+upload_protocol = esptool
+
+; --------------------------------------------------------------------------
+; Native test environments using EpoxyDuino + AUnit (no hardware required)
+; Run with: pio test -e test_core   /   pio test -e test_context
+; --------------------------------------------------------------------------
+
+[env:test_core]
+platform = native
+lib_deps =
+    https://github.com/bxparks/EpoxyDuino.git#v1.6.0
+    bxparks/AUnit@^1.7.1
+lib_ldf_mode = deep+
+lib_compat_mode = off
+lib_ignore = Unity
+build_flags =
+    -std=c++11
+    -Wall
+    -Wno-deprecated-declarations
+    -DEPOXY_DUINO
+    -DEPOXY_CORE_ESP8266
+    -DARDUINO_ESP8266
+    -DESP8266
+build_src_filter = +<*> -<examples/>
+test_build_src = true
+test_filter = test_core
+
+[env:test_context]
+platform = native
+lib_deps =
+    https://github.com/bxparks/EpoxyDuino.git#v1.6.0
+    bxparks/AUnit@^1.7.1
+lib_ldf_mode = deep+
+lib_compat_mode = off
+lib_ignore = Unity
+build_flags =
+    -std=c++11
+    -Wall
+    -Wno-deprecated-declarations
+    -DEPOXY_DUINO
+    -DEPOXY_CORE_ESP8266
+    -DARDUINO_ESP8266
+    -DESP8266
+build_src_filter = +<*> -<examples/>
+test_build_src = true
+test_filter = test_context

--- a/src/ESPRotary.cpp
+++ b/src/ESPRotary.cpp
@@ -189,6 +189,16 @@ void ESPRotary::setID(int newID) {
 
 /////////////////////////////////////////////////////////////////
 
+void ESPRotary::setContext(void* ctx) {
+  context = ctx;
+}
+
+void* ESPRotary::getContext() const {
+  return context;
+}
+
+/////////////////////////////////////////////////////////////////
+
 bool ESPRotary::operator==(const ESPRotary& rhs) const {
   return (this == &rhs);
 }

--- a/src/ESPRotary.h
+++ b/src/ESPRotary.h
@@ -66,6 +66,8 @@ class ESPRotary {
   CallbackFunction speedup_start_cb = NULL;
   CallbackFunction speedup_end_cb = NULL;
 
+  void* context = nullptr;
+
  public:
   ESPRotary();
   ESPRotary(byte pin1, byte pin2, byte steps_per_click = 1, int lower_bound = INT16_MIN, int upper_bound = INT16_MAX, int initial_pos = 0, int increment = 1);
@@ -112,6 +114,9 @@ class ESPRotary {
 
   int getID() const;
   void setID(int newID);
+
+  void setContext(void* ctx);
+  void* getContext() const;
 
   bool operator==(const ESPRotary& rhs) const;
 

--- a/test/shared/test_helpers.h
+++ b/test/shared/test_helpers.h
@@ -1,0 +1,32 @@
+/////////////////////////////////////////////////////////////////
+/*
+  Shared test helpers for ESPRotary test suites.
+
+  ESPRotary reads its pins directly via digitalRead() (there is no
+  injectable pin-state function like Button2 has), so the native
+  suites focus on public API / state behavior rather than simulating
+  quadrature edges.
+*/
+/////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <Arduino.h>
+#include <ESPRotary.h>
+
+/////////////////////////////////////////////////////////////////
+
+#define ROTARY_PIN1     12
+#define ROTARY_PIN2     13
+#define CLICKS_PER_STEP 4
+
+/////////////////////////////////////////////////////////////////
+
+// Create a rotary encoder configured for tests.
+inline ESPRotary createTestRotary() {
+  ESPRotary r;
+  r.begin(ROTARY_PIN1, ROTARY_PIN2, CLICKS_PER_STEP);
+  return r;
+}
+
+/////////////////////////////////////////////////////////////////

--- a/test/test_context/test_context.cpp
+++ b/test/test_context/test_context.cpp
@@ -1,0 +1,79 @@
+/////////////////////////////////////////////////////////////////
+/*
+  Tests for the setContext() / getContext() feature (issue #48).
+  A void* context is stored on the encoder and retrieved inside a
+  callback via the passed ESPRotary&, letting a global callback be
+  routed back to the object that owns the encoder.
+*/
+/////////////////////////////////////////////////////////////////
+
+#include <Arduino.h>
+#include <AUnitVerbose.h>
+#include "../shared/test_helpers.h"
+
+using namespace aunit;
+
+/////////////////////////////////////////////////////////////////
+
+#define SERIAL_SPEED 115200
+
+/////////////////////////////////////////////////////////////////
+
+// Stand-in for the "object that owns the rotary" from issue #48.
+struct Owner {
+  int handled = 0;
+};
+
+static Owner callbackOwner;
+
+// Free-function callback that recovers its owner through the context.
+void onChange(ESPRotary& r) {
+  Owner* owner = static_cast<Owner*>(r.getContext());
+  if (owner != nullptr) owner->handled++;
+}
+
+/////////////////////////////////////////////////////////////////
+
+test(context, defaults_to_null) {
+  ESPRotary r = createTestRotary();
+  assertTrue(r.getContext() == nullptr);
+}
+
+test(context, set_and_get) {
+  ESPRotary r = createTestRotary();
+  Owner owner;
+  r.setContext(&owner);
+  assertTrue(r.getContext() == &owner);
+}
+
+test(context, retrievable_inside_callback) {
+  ESPRotary r = createTestRotary();
+  callbackOwner.handled = 0;
+  r.setContext(&callbackOwner);
+  r.setChangedHandler(onChange);
+
+  // resetPosition(..., true) fires the changed handler.
+  r.resetPosition(3, true);
+
+  assertEqual(callbackOwner.handled, 1);
+}
+
+/////////////////////////////////////////////////////////////////
+
+void setup() {
+  delay(100);
+  Serial.begin(SERIAL_SPEED);
+  while (!Serial) {}
+  Serial.println(F("\n\nESPRotary Context Tests"));
+  Serial.println(F("Using EpoxyDuino + AUnit"));
+  TestRunner::setVerbosity(Verbosity::kDefault);
+  TestRunner::setTimeout(90);
+}
+
+/////////////////////////////////////////////////////////////////
+
+void loop() {
+  aunit::TestRunner::run();
+}
+
+/////////////////////////////////////////////////////////////////

--- a/test/test_core/test_core.cpp
+++ b/test/test_core/test_core.cpp
@@ -1,0 +1,157 @@
+/////////////////////////////////////////////////////////////////
+/*
+  Core behavior tests for the ESPRotary library.
+  Locks in the existing public API / state behavior (position,
+  bounds, increment, direction, speedup config, IDs) as a safety
+  net. Native testing via EpoxyDuino + AUnit, no hardware required.
+*/
+/////////////////////////////////////////////////////////////////
+
+#include <Arduino.h>
+#include <AUnitVerbose.h>
+#include "../shared/test_helpers.h"
+
+using namespace aunit;
+
+/////////////////////////////////////////////////////////////////
+
+#define SERIAL_SPEED 115200
+
+/////////////////////////////////////////////////////////////////
+// IDs & equality
+/////////////////////////////////////////////////////////////////
+
+test(core, ids_are_unique) {
+  ESPRotary a;
+  ESPRotary b;
+  assertNotEqual(a.getID(), b.getID());
+}
+
+test(core, set_id_overrides) {
+  ESPRotary r;
+  r.setID(4242);
+  assertEqual(r.getID(), 4242);
+}
+
+test(core, equal_operator) {
+  ESPRotary a = createTestRotary();
+  ESPRotary b = createTestRotary();
+  assertTrue(a == a);
+  assertFalse(a == b);
+}
+
+/////////////////////////////////////////////////////////////////
+// Position
+/////////////////////////////////////////////////////////////////
+
+test(core, reset_position) {
+  ESPRotary r = createTestRotary();
+  r.resetPosition(7, false);
+  assertEqual(r.getPosition(), 7);
+}
+
+test(core, reset_position_clamps_to_bounds) {
+  ESPRotary r;
+  r.begin(ROTARY_PIN1, ROTARY_PIN2, CLICKS_PER_STEP, 0, 10);
+  r.resetPosition(25, false);
+  assertEqual(r.getPosition(), 10);
+}
+
+/////////////////////////////////////////////////////////////////
+// Bounds
+/////////////////////////////////////////////////////////////////
+
+test(core, set_and_get_bounds) {
+  ESPRotary r = createTestRotary();
+  r.setUpperBound(100);
+  r.setLowerBound(10);
+  assertEqual(r.getUpperBound(), 100);
+  assertEqual(r.getLowerBound(), 10);
+}
+
+test(core, upper_bound_cannot_drop_below_lower) {
+  ESPRotary r = createTestRotary();
+  r.setLowerBound(10);
+  r.setUpperBound(100);
+  // Try to move the upper bound below the lower bound: it is refused.
+  r.setUpperBound(5);
+  assertEqual(r.getUpperBound(), 10);
+}
+
+/////////////////////////////////////////////////////////////////
+// Increment & steps per click
+/////////////////////////////////////////////////////////////////
+
+test(core, increment) {
+  ESPRotary r = createTestRotary();
+  assertEqual(r.getIncrement(), 1);
+  r.setIncrement(10);
+  assertEqual(r.getIncrement(), 10);
+}
+
+test(core, steps_per_click_floors_at_one) {
+  ESPRotary r = createTestRotary();
+  assertEqual(r.getStepsPerClick(), CLICKS_PER_STEP);
+  r.setStepsPerClick(0);
+  assertEqual(r.getStepsPerClick(), 1);
+}
+
+/////////////////////////////////////////////////////////////////
+// Direction
+/////////////////////////////////////////////////////////////////
+
+test(core, direction_default_is_undefined) {
+  ESPRotary r = createTestRotary();
+  assertTrue(r.getDirection() == rotary_direction::undefined);
+}
+
+test(core, direction_to_string) {
+  ESPRotary r = createTestRotary();
+  assertTrue(r.directionToString(rotary_direction::right) == "right");
+  assertTrue(r.directionToString(rotary_direction::left) == "left");
+  assertTrue(r.directionToString(rotary_direction::undefined) == "undefined");
+}
+
+/////////////////////////////////////////////////////////////////
+// Speedup configuration
+/////////////////////////////////////////////////////////////////
+
+test(core, speedup_toggle) {
+  ESPRotary r = createTestRotary();
+  assertFalse(r.isSpeedupEnabled());
+  r.enableSpeedup(true);
+  assertTrue(r.isSpeedupEnabled());
+}
+
+test(core, speedup_interval_and_increment) {
+  ESPRotary r = createTestRotary();
+  r.setSpeedupInterval(120);
+  r.setSpeedupIncrement(8);
+  assertEqual(r.getSpeedupInterval(), 120);
+  assertEqual(r.getSpeedupIncrement(), 8);
+}
+
+test(core, not_in_speedup_by_default) {
+  ESPRotary r = createTestRotary();
+  assertFalse(r.isInSpeedup());
+}
+
+/////////////////////////////////////////////////////////////////
+
+void setup() {
+  delay(100);
+  Serial.begin(SERIAL_SPEED);
+  while (!Serial) {}
+  Serial.println(F("\n\nESPRotary Core Tests"));
+  Serial.println(F("Using EpoxyDuino + AUnit"));
+  TestRunner::setVerbosity(Verbosity::kDefault);
+  TestRunner::setTimeout(90);
+}
+
+/////////////////////////////////////////////////////////////////
+
+void loop() {
+  aunit::TestRunner::run();
+}
+
+/////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

Adds a way to give the plain-function callbacks access to custom state — most commonly a pointer to the object that *owns* the encoder — without a breaking change to the callback signature. Resolves #48.

Instead of adding a `void*` parameter to every callback signature and handler setter (which would change the `CallbackFunction` typedef and break every existing sketch), a single context is stored on the encoder instance and recovered inside the handler via the already-passed `ESPRotary&`. This mirrors the pattern already used in the [Button2](https://github.com/LennartHennigs/Button2) library.

```cpp
void  setContext(void* ctx);
void* getContext() const;
```

```cpp
r.setContext(this);                       // pass the owning object
// inside the handler:
auto* self = static_cast<Dial*>(sender.getContext());
```

## Changes

- `setContext(void*)` / `getContext()` in `src/ESPRotary.{h,cpp}` (non-breaking)
- New `Context` example demonstrating the owning-object pattern
- Native test harness (PlatformIO + EpoxyDuino + AUnit), mirroring Button2:
  - `test/test_core` — 14 core-behavior tests (backfilled safety net)
  - `test/test_context` — 3 tests for the new feature (added test-first)
- README, CHANGELOG, `keywords.txt` updates; version bumped to **2.2.0**

## Verification

- `pio test -e test_core` → 14 passed
- `pio test -e test_context` → 3 passed
- `arduino-cli compile` of `examples/Context` and `examples/SimpleCounter` (ESP8266 D1) — both build clean

https://claude.ai/code/session_01D43Q16eWAx25uiUC8wArBi