### PR TITLE
fix: phantom event after resetPosition/initial_pos + rotation test seam (2.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## [2.2.1] - 2026-07-27
 
 - Fixed a phantom rotation/change event fired on the first `loop()` after `resetPosition()` or after `begin()` with a non-zero `initial_pos`; `last_steps` was left stale so the next `loop()` decoded a large bogus step difference
+- Fixed a negative `increment` making the rotation threshold negative, which fired an event on every `loop()`; the threshold now uses `abs(increment)`, so a negative increment cleanly inverts the counting direction (useful for reversed wiring)
+- Fixed `setStepsPerClick()` silently changing the reported position when called after some rotation; it now rescales `steps` to keep `getPosition()` stable
 - Added `setPinReadFunction()` — an optional override for how the encoder pins are read (defaults to `digitalRead`), used as a test seam to simulate rotation without hardware
-- Added a `test_rotation` suite covering the decode/event engine (rotation, direction, bound overflow callbacks, speedup) plus regression tests for the phantom-event fix
+- Added a `test_rotation` suite covering the decode/event engine (rotation, direction, bound overflow callbacks, speedup) plus regression tests for the fixes above
 
 ## [2.2.0] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.2.1] - 2026-07-27
+
+- Fixed a phantom rotation/change event fired on the first `loop()` after `resetPosition()` or after `begin()` with a non-zero `initial_pos`; `last_steps` was left stale so the next `loop()` decoded a large bogus step difference
+- Added `setPinReadFunction()` — an optional override for how the encoder pins are read (defaults to `digitalRead`), used as a test seam to simulate rotation without hardware
+- Added a `test_rotation` suite covering the decode/event engine (rotation, direction, bound overflow callbacks, speedup) plus regression tests for the phantom-event fix
+
 ## [2.2.0] - 2026-07-27
 
 - Added `setContext(void*)` / `getContext()` to attach a custom context (typically a pointer to the object that owns the encoder) to an instance, retrievable inside callbacks via the passed `ESPRotary&`. This is the recommended way to give the plain-function callbacks access to custom state. Resolves [#48](https://github.com/LennartHennigs/ESPRotary/issues/48)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ The library is a single class (`ESPRotary`) split into two files:
 - `retriggerEvent(false)` suppresses repeated boundary events; `triggerOnBounds(false)` suppresses rotation callbacks when at a boundary
 - Each instance gets a static auto-incremented `id`
 - `setContext(void*)` / `getContext()` store an arbitrary pointer on the instance (usually the owning object) so the plain-function callbacks can recover custom state via the passed `ESPRotary&`
+- **Invariant:** `_wasRotated()` fires on `abs(steps - last_steps)` crossing a threshold, so anywhere `steps` is assigned directly (outside `loop()` — i.e. `resetPosition()` and `begin()`'s `initial_pos`) must also set `last_steps = steps`, or the next `loop()` decodes a phantom rotation/change event
+- `setPinReadFunction(fn)` overrides how the pins are read (defaults to `digitalRead`); it exists as a test seam so rotation can be simulated on the host
 
 ## Development
 
@@ -45,6 +47,7 @@ Test sources live in `test/test_*/` with shared helpers in `test/shared/test_hel
 - `examples/SimpleCounter` — basic rotation and direction callbacks
 - `examples/RangedCounter` — bounds and overflow callbacks
 - `examples/Speedup` — speedup mode
+- `examples/Context` — passing an owning object to callbacks via `setContext()`
 - `examples/ESP32Interrupt` / `examples/ESP8266Interrupt` — timer interrupt usage instead of `loop()`
 
 ## Release Process

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-ESPRotary is an Arduino/ESP library (v2.2.0) for reading rotary encoder values via callback functions. It targets Arduino, ESP8266, and ESP32 devices and is distributed through the Arduino IDE Library Manager and PlatformIO.
+ESPRotary is an Arduino/ESP library (v2.2.1) for reading rotary encoder values via callback functions. It targets Arduino, ESP8266, and ESP32 devices and is distributed through the Arduino IDE Library Manager and PlatformIO.
 
 ## Architecture
 
@@ -34,7 +34,10 @@ The `.vscode/arduino.json` is configured for an ESP8266 D1 Mini on `/dev/tty.usb
 ```
 pio test -e test_core      # core behavior (position, bounds, direction, speedup, IDs)
 pio test -e test_context   # setContext / getContext
+pio test -e test_rotation  # decode/event engine via the setPinReadFunction() seam
 ```
+
+The `test_rotation` suite drives a simulated quadrature signal through `setPinReadFunction()` (a settable pin-read override that defaults to `digitalRead`), letting `loop()`, the decode table, and event callbacks be tested without hardware.
 
 Test sources live in `test/test_*/` with shared helpers in `test/shared/test_helpers.h`; env config is in `platformio.ini`. Note: PlatformIO reports "0 test cases" because it doesn't parse AUnit's output — a green (exit 0) run means the AUnit assertions passed; run `.pio/build/<env>/program` directly to see the per-test summary.
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -32,5 +32,6 @@ getID	KEYWORD2
 setID	KEYWORD2
 setContext	KEYWORD2
 getContext	KEYWORD2
+setPinReadFunction	KEYWORD2
 loop	KEYWORD2
 direction	LITERAL1

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
 	"name": "ESP Rotary",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"keywords": "rotary encoder, esp8266",
 	"description": "ESP8266/Arduino Library for reading rotary encoder values.",
 	"homepage": "https://github.com/LennartHennigs/ESPRotary",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP Rotary
-version=2.2.0
+version=2.2.1
 author=Lennart Hennigs
 maintainer=Lennart Hennigs <mail@lennarthennigs.de>
 sentence=ESP8266/Arduino Library for reading rotary encoder values.

--- a/platformio.ini
+++ b/platformio.ini
@@ -58,3 +58,23 @@ build_flags =
 build_src_filter = +<*> -<examples/>
 test_build_src = true
 test_filter = test_context
+
+[env:test_rotation]
+platform = native
+lib_deps =
+    https://github.com/bxparks/EpoxyDuino.git#v1.6.0
+    bxparks/AUnit@^1.7.1
+lib_ldf_mode = deep+
+lib_compat_mode = off
+lib_ignore = Unity
+build_flags =
+    -std=c++11
+    -Wall
+    -Wno-deprecated-declarations
+    -DEPOXY_DUINO
+    -DEPOXY_CORE_ESP8266
+    -DARDUINO_ESP8266
+    -DESP8266
+build_src_filter = +<*> -<examples/>
+test_build_src = true
+test_filter = test_rotation

--- a/src/ESPRotary.cpp
+++ b/src/ESPRotary.cpp
@@ -47,6 +47,7 @@ void ESPRotary::begin(byte pin1, byte pin2, byte steps_per_click /* = 1 */, int 
 
   loop();
   steps = initial_pos * steps_per_click;
+  last_steps = steps;
   last_event = rotary_event::none;
   dir = rotary_direction::undefined;
 }
@@ -125,6 +126,7 @@ void ESPRotary::resetPosition(int p /* = 0 */, bool fireCallback /* = true */) {
   // yes...
   steps = p * steps_per_click;
   _isWithinBounds();
+  last_steps = steps;
   if (fireCallback) _callCallback(change_cb);
   last_event = rotary_event::none;
   dir = rotary_direction::undefined;
@@ -199,6 +201,12 @@ void* ESPRotary::getContext() const {
 
 /////////////////////////////////////////////////////////////////
 
+void ESPRotary::setPinReadFunction(PinReadFunction f) {
+  pinReadFn = (f != NULL) ? f : digitalRead;
+}
+
+/////////////////////////////////////////////////////////////////
+
 bool ESPRotary::operator==(const ESPRotary& rhs) const {
   return (this == &rhs);
 }
@@ -225,7 +233,7 @@ void ESPRotary::loop() {
 
 bool ESPRotary::_wasRotated() {
   static const int8_t factors[] = {0, 1, -1, 2, -1, 0, -2, 1, 1, -2, 0, -1, 2, -1, 1, 0};
-  int encoderState = (state & 3) | digitalRead(pin1) << 2 | digitalRead(pin2) << 3 ;
+  int encoderState = (state & 3) | pinReadFn(pin1) << 2 | pinReadFn(pin2) << 3 ;
   steps += factors[encoderState] * increment;
   state = (encoderState >> 2);
   int stepDifference = abs(steps - last_steps);

--- a/src/ESPRotary.cpp
+++ b/src/ESPRotary.cpp
@@ -147,8 +147,12 @@ int ESPRotary::getIncrement() const {
 
 /////////////////////////////////////////////////////////////////
 
-void ESPRotary::setStepsPerClick(int steps) {
-  steps_per_click = (steps < 1) ? 1 : steps;
+void ESPRotary::setStepsPerClick(int newStepsPerClick) {
+  int pos = getPosition();
+  steps_per_click = (newStepsPerClick < 1) ? 1 : newStepsPerClick;
+  // keep the reported position stable when the divisor changes
+  steps = pos * steps_per_click;
+  last_steps = steps;
 }
 
 /////////////////////////////////////////////////////////////////
@@ -237,7 +241,9 @@ bool ESPRotary::_wasRotated() {
   steps += factors[encoderState] * increment;
   state = (encoderState >> 2);
   int stepDifference = abs(steps - last_steps);
-  return stepDifference >= (steps_per_click * increment);
+  // abs(increment) so a negative increment (reversed wiring) inverts the
+  // direction without making the threshold negative (which would fire every loop)
+  return stepDifference >= (steps_per_click * abs(increment));
 }
 
 /////////////////////////////////////////////////////////////////

--- a/src/ESPRotary.h
+++ b/src/ESPRotary.h
@@ -56,7 +56,10 @@ class ESPRotary {
   unsigned long last_turn = 0;
 
   using CallbackFunction = void (*)(ESPRotary&);
-  
+  using PinReadFunction = int (*)(uint8_t);
+
+  PinReadFunction pinReadFn = digitalRead;
+
   CallbackFunction change_cb = NULL;
   CallbackFunction right_cb = NULL;
   CallbackFunction left_cb = NULL;
@@ -117,6 +120,10 @@ class ESPRotary {
 
   void setContext(void* ctx);
   void* getContext() const;
+
+  // Override how the encoder pins are read (defaults to digitalRead).
+  // Mainly a test seam to simulate rotation without hardware.
+  void setPinReadFunction(PinReadFunction f);
 
   bool operator==(const ESPRotary& rhs) const;
 

--- a/test/shared/test_helpers.h
+++ b/test/shared/test_helpers.h
@@ -2,10 +2,10 @@
 /*
   Shared test helpers for ESPRotary test suites.
 
-  ESPRotary reads its pins directly via digitalRead() (there is no
-  injectable pin-state function like Button2 has), so the native
-  suites focus on public API / state behavior rather than simulating
-  quadrature edges.
+  ESPRotary normally reads its pins via digitalRead(). For host tests
+  we install a fake pin-read function (setPinReadFunction) and drive
+  a simulated quadrature signal, so rotation can be exercised without
+  hardware.
 */
 /////////////////////////////////////////////////////////////////
 
@@ -21,12 +21,50 @@
 #define CLICKS_PER_STEP 4
 
 /////////////////////////////////////////////////////////////////
+// Simulated pin state: bit0 = pin1 level, bit1 = pin2 level.
 
-// Create a rotary encoder configured for tests.
+static uint8_t simPinState = 0;
+
+inline int fakePinRead(uint8_t pin) {
+  if (pin == ROTARY_PIN1) return simPinState & 1;
+  if (pin == ROTARY_PIN2) return (simPinState >> 1) & 1;
+  return 0;
+}
+
+/////////////////////////////////////////////////////////////////
+
+// Create a rotary encoder wired to the simulated pins.
 inline ESPRotary createTestRotary() {
+  simPinState = 0;
   ESPRotary r;
+  r.setPinReadFunction(fakePinRead);
   r.begin(ROTARY_PIN1, ROTARY_PIN2, CLICKS_PER_STEP);
   return r;
+}
+
+/////////////////////////////////////////////////////////////////
+
+// One detent right = the quadrature phases 2 -> 3 -> 1 -> 0
+// (each transition decodes to +1, so a full detent is +CLICKS_PER_STEP).
+inline void turnRight(ESPRotary& r, int detents = 1) {
+  static const uint8_t seq[] = {2, 3, 1, 0};
+  for (int d = 0; d < detents; d++) {
+    for (uint8_t i = 0; i < 4; i++) {
+      simPinState = seq[i];
+      r.loop();
+    }
+  }
+}
+
+// One detent left = the reverse phases 1 -> 3 -> 2 -> 0 (each -1).
+inline void turnLeft(ESPRotary& r, int detents = 1) {
+  static const uint8_t seq[] = {1, 3, 2, 0};
+  for (int d = 0; d < detents; d++) {
+    for (uint8_t i = 0; i < 4; i++) {
+      simPinState = seq[i];
+      r.loop();
+    }
+  }
 }
 
 /////////////////////////////////////////////////////////////////

--- a/test/test_rotation/test_rotation.cpp
+++ b/test/test_rotation/test_rotation.cpp
@@ -1,0 +1,157 @@
+/////////////////////////////////////////////////////////////////
+/*
+  Rotation / event-engine tests for ESPRotary.
+
+  Uses the setPinReadFunction() seam (see test_helpers.h) to drive a
+  simulated quadrature signal, so loop(), the decode table, direction
+  detection, bound overflow events and speedup can be exercised on the
+  host. Also contains regression tests for reported bugs.
+*/
+/////////////////////////////////////////////////////////////////
+
+#include <Arduino.h>
+#include <AUnitVerbose.h>
+#include "../shared/test_helpers.h"
+
+using namespace aunit;
+
+/////////////////////////////////////////////////////////////////
+
+#define SERIAL_SPEED 115200
+
+/////////////////////////////////////////////////////////////////
+// Callback counters
+
+int changeCount = 0;
+int leftCount = 0;
+int rightCount = 0;
+int upperCount = 0;
+int lowerCount = 0;
+
+void onChange(ESPRotary&) { changeCount++; }
+void onLeft(ESPRotary&) { leftCount++; }
+void onRight(ESPRotary&) { rightCount++; }
+void onUpper(ESPRotary&) { upperCount++; }
+void onLower(ESPRotary&) { lowerCount++; }
+
+void resetCounters() {
+  changeCount = leftCount = rightCount = upperCount = lowerCount = 0;
+}
+
+/////////////////////////////////////////////////////////////////
+// Characterization: basic rotation
+/////////////////////////////////////////////////////////////////
+
+test(rotation, turn_right_increments_position) {
+  ESPRotary r = createTestRotary();
+  turnRight(r, 1);
+  assertEqual(r.getPosition(), 1);
+  assertTrue(r.getDirection() == rotary_direction::right);
+}
+
+test(rotation, turn_left_decrements_position) {
+  ESPRotary r = createTestRotary();
+  turnLeft(r, 1);
+  assertEqual(r.getPosition(), -1);
+  assertTrue(r.getDirection() == rotary_direction::left);
+}
+
+test(rotation, multiple_detents) {
+  ESPRotary r = createTestRotary();
+  turnRight(r, 5);
+  assertEqual(r.getPosition(), 5);
+  turnLeft(r, 2);
+  assertEqual(r.getPosition(), 3);
+}
+
+test(rotation, change_callback_fires_once_per_detent) {
+  ESPRotary r = createTestRotary();
+  resetCounters();
+  r.setChangedHandler(onChange);
+  r.setRightRotationHandler(onRight);
+  turnRight(r, 3);
+  assertEqual(changeCount, 3);
+  assertEqual(rightCount, 3);
+}
+
+/////////////////////////////////////////////////////////////////
+// Characterization: bounds & overflow callbacks
+/////////////////////////////////////////////////////////////////
+
+test(rotation, clamps_at_upper_bound_and_fires_overflow) {
+  ESPRotary r;
+  simPinState = 0;
+  r.setPinReadFunction(fakePinRead);
+  r.begin(ROTARY_PIN1, ROTARY_PIN2, CLICKS_PER_STEP, 0, 2);
+  resetCounters();
+  r.setUpperOverflowHandler(onUpper);
+  turnRight(r, 5);
+  assertEqual(r.getPosition(), 2);
+  assertMoreOrEqual(upperCount, 1);
+}
+
+/////////////////////////////////////////////////////////////////
+// Probe: does speedup reverse direction? (review finding #1)
+// Net position change per detent under speedup should stay positive
+// for a rightward turn even when increment > speedup_increment.
+/////////////////////////////////////////////////////////////////
+
+test(rotation, speedup_does_not_reverse_direction) {
+  ESPRotary r = createTestRotary();
+  r.enableSpeedup(true);
+  r.setSpeedupInterval(100000);  // force the speedup path
+  r.setSpeedupIncrement(5);
+  r.setIncrement(10);
+  turnRight(r, 3);
+  assertMore(r.getPosition(), 0);
+  assertTrue(r.getDirection() == rotary_direction::right);
+}
+
+/////////////////////////////////////////////////////////////////
+// Regression: no phantom event after resetPosition / initial_pos
+// (review finding #2 — last_steps left stale)
+/////////////////////////////////////////////////////////////////
+
+test(rotation, no_phantom_event_after_reset) {
+  ESPRotary r = createTestRotary();
+  r.setChangedHandler(onChange);
+  r.setRightRotationHandler(onRight);
+  resetCounters();
+  r.resetPosition(50, false);  // reposition without firing a callback
+  r.loop();                    // no rotation happened
+  assertEqual(changeCount, 0);
+  assertEqual(rightCount, 0);
+  assertEqual(r.getPosition(), 50);
+}
+
+test(rotation, no_phantom_event_after_begin_with_initial_pos) {
+  simPinState = 0;
+  ESPRotary r;
+  r.setPinReadFunction(fakePinRead);
+  r.begin(ROTARY_PIN1, ROTARY_PIN2, CLICKS_PER_STEP, INT16_MIN, INT16_MAX, 50);
+  r.setChangedHandler(onChange);
+  resetCounters();
+  r.loop();  // first loop after begin, no rotation
+  assertEqual(changeCount, 0);
+  assertEqual(r.getPosition(), 50);
+}
+
+/////////////////////////////////////////////////////////////////
+
+void setup() {
+  delay(100);
+  Serial.begin(SERIAL_SPEED);
+  while (!Serial) {}
+  Serial.println(F("\n\nESPRotary Rotation Tests"));
+  Serial.println(F("Using EpoxyDuino + AUnit"));
+  TestRunner::setVerbosity(Verbosity::kDefault);
+  TestRunner::setTimeout(90);
+}
+
+/////////////////////////////////////////////////////////////////
+
+void loop() {
+  aunit::TestRunner::run();
+}
+
+/////////////////////////////////////////////////////////////////

--- a/test/test_rotation/test_rotation.cpp
+++ b/test/test_rotation/test_rotation.cpp
@@ -27,15 +27,29 @@ int leftCount = 0;
 int rightCount = 0;
 int upperCount = 0;
 int lowerCount = 0;
+int speedupStartCount = 0;
+int speedupEndCount = 0;
 
 void onChange(ESPRotary&) { changeCount++; }
 void onLeft(ESPRotary&) { leftCount++; }
 void onRight(ESPRotary&) { rightCount++; }
 void onUpper(ESPRotary&) { upperCount++; }
 void onLower(ESPRotary&) { lowerCount++; }
+void onSpeedupStart(ESPRotary&) { speedupStartCount++; }
+void onSpeedupEnd(ESPRotary&) { speedupEndCount++; }
 
 void resetCounters() {
   changeCount = leftCount = rightCount = upperCount = lowerCount = 0;
+  speedupStartCount = speedupEndCount = 0;
+}
+
+// Build an encoder on the simulated pins with explicit bounds.
+inline ESPRotary makeRotary(int lower, int upper) {
+  simPinState = 0;
+  ESPRotary r;
+  r.setPinReadFunction(fakePinRead);
+  r.begin(ROTARY_PIN1, ROTARY_PIN2, CLICKS_PER_STEP, lower, upper);
+  return r;
 }
 
 /////////////////////////////////////////////////////////////////
@@ -164,6 +178,105 @@ test(rotation, steps_per_click_change_preserves_position) {
   assertEqual(r.getPosition(), 3);
   r.setStepsPerClick(2);
   assertEqual(r.getPosition(), 3);
+}
+
+/////////////////////////////////////////////////////////////////
+// Characterization: bound event options
+/////////////////////////////////////////////////////////////////
+
+test(rotation, trigger_on_bounds_false_suppresses_rotation_callback) {
+  ESPRotary r = makeRotary(0, 2);
+  r.triggerOnBounds(false);
+  resetCounters();
+  r.setChangedHandler(onChange);
+  r.setUpperOverflowHandler(onUpper);
+  turnRight(r, 3);
+  // change fires only for the in-bounds detent, not on the bound hit
+  assertEqual(changeCount, 1);
+  assertMoreOrEqual(upperCount, 1);
+}
+
+test(rotation, retrigger_event_false_fires_bound_once) {
+  ESPRotary r = makeRotary(0, 2);
+  r.retriggerEvent(false);
+  resetCounters();
+  r.setUpperOverflowHandler(onUpper);
+  turnRight(r, 4);  // reaches the bound, then keeps pushing against it
+  assertEqual(upperCount, 1);
+}
+
+test(rotation, lower_bound_overflow_clamps_and_fires) {
+  ESPRotary r = makeRotary(-2, 2);
+  resetCounters();
+  r.setLowerOverflowHandler(onLower);
+  turnLeft(r, 5);
+  assertEqual(r.getPosition(), -2);
+  assertMoreOrEqual(lowerCount, 1);
+}
+
+/////////////////////////////////////////////////////////////////
+// Characterization: getLastEvent, left handler, resetPosition callback
+/////////////////////////////////////////////////////////////////
+
+test(rotation, get_last_event_tracks_events) {
+  ESPRotary r = createTestRotary();
+  assertTrue(r.getLastEvent() == rotary_event::none);
+  turnRight(r, 1);
+  assertTrue(r.getLastEvent() == rotary_event::right_rotation);
+  turnLeft(r, 1);
+  assertTrue(r.getLastEvent() == rotary_event::left_rotation);
+}
+
+test(rotation, get_last_event_reports_upper_bound_hit) {
+  ESPRotary r = makeRotary(0, 2);
+  turnRight(r, 4);
+  assertTrue(r.getLastEvent() == rotary_event::upper_bound_hit);
+}
+
+test(rotation, left_rotation_handler_fires_per_detent) {
+  ESPRotary r = createTestRotary();
+  resetCounters();
+  r.setLeftRotationHandler(onLeft);
+  turnLeft(r, 2);
+  assertEqual(leftCount, 2);
+}
+
+test(rotation, reset_position_with_callback_fires_once) {
+  ESPRotary r = createTestRotary();
+  resetCounters();
+  r.setChangedHandler(onChange);
+  r.resetPosition(10);  // fireCallback defaults to true
+  assertEqual(changeCount, 1);
+  assertEqual(r.getPosition(), 10);
+  r.loop();             // no phantom on the following loop
+  assertEqual(changeCount, 1);
+}
+
+/////////////////////////////////////////////////////////////////
+// Characterization: speedup engages and ends
+/////////////////////////////////////////////////////////////////
+
+test(rotation, speedup_engages_on_fast_rotation) {
+  ESPRotary r = createTestRotary();
+  r.enableSpeedup(true);
+  resetCounters();
+  r.setSpeedupStartedHandler(onSpeedupStart);
+  turnRight(r, 4);  // consecutive detents are microseconds apart
+  assertTrue(r.isInSpeedup());
+  assertMore(speedupStartCount, 0);
+}
+
+test(rotation, speedup_ends_after_idle) {
+  ESPRotary r = createTestRotary();
+  r.enableSpeedup(true);
+  r.setSpeedupEndedHandler(onSpeedupEnd);
+  turnRight(r, 4);
+  assertTrue(r.isInSpeedup());
+  resetCounters();
+  delay(r.getSpeedupInterval() + 30);  // let the encoder go "idle"
+  turnRight(r, 1);                        // this slow detent ends speedup
+  assertFalse(r.isInSpeedup());
+  assertMore(speedupEndCount, 0);
 }
 
 /////////////////////////////////////////////////////////////////

--- a/test/test_rotation/test_rotation.cpp
+++ b/test/test_rotation/test_rotation.cpp
@@ -137,6 +137,36 @@ test(rotation, no_phantom_event_after_begin_with_initial_pos) {
 }
 
 /////////////////////////////////////////////////////////////////
+// Regression: a negative increment should invert direction and still
+// fire exactly one event per detent (review finding #5 — the rotation
+// threshold went negative and fired on every loop()).
+/////////////////////////////////////////////////////////////////
+
+test(rotation, negative_increment_reverses_and_fires_once) {
+  ESPRotary r = createTestRotary();
+  r.setIncrement(-1);
+  r.setChangedHandler(onChange);
+  resetCounters();
+  turnRight(r, 1);
+  assertEqual(changeCount, 1);
+  assertEqual(r.getPosition(), -1);
+  assertTrue(r.getDirection() == rotary_direction::left);
+}
+
+/////////////////////////////////////////////////////////////////
+// Regression: changing steps_per_click at runtime should keep the
+// reported position (review finding #3 — it silently rescaled).
+/////////////////////////////////////////////////////////////////
+
+test(rotation, steps_per_click_change_preserves_position) {
+  ESPRotary r = createTestRotary();
+  turnRight(r, 3);
+  assertEqual(r.getPosition(), 3);
+  r.setStepsPerClick(2);
+  assertEqual(r.getPosition(), 3);
+}
+
+/////////////////////////////////////////////////////////////////
 
 void setup() {
   delay(100);


### PR DESCRIPTION
Follow-up to #50. Adds host-testability for the rotation engine and addresses the correctness findings from the code review, all written **test-first (TDD)**.

## Fixes

**#2 — phantom event (high severity).** `resetPosition()` and `begin()` with a non-zero `initial_pos` assigned `steps` but never updated `last_steps`, so the next `loop()` decoded a large bogus step difference and fired a spurious rotation + change callback with a made-up direction. Fix: sync `last_steps = steps` in both places.

**#5 — negative increment fired every loop.** The rotation threshold was `steps_per_click * increment`; a negative increment made it negative so `_wasRotated()` returned true on every `loop()`. Fix: use `abs(increment)`. As a bonus this makes a negative increment a clean **reverse-direction** feature (for reversed wiring) instead of a bug.

**#3 — setStepsPerClick rescaled position.** Calling it after some rotation silently changed `getPosition()` (it only swapped the divisor). Fix: rescale `steps` so the reported position stays stable. Also fixed a latent variable-shadow (the param was named `steps`, shadowing the member).

## Not changed

**#1 — suspected speedup direction reversal: retracted.** Writing the test (`speedup_does_not_reverse_direction`) showed it does **not** reproduce — `_wasRotated()` already adds the base `increment`, so net movement per detent stays `speedup_increment` (positive). This is exactly why the tests came first.

**#6 — getPosition truncates toward zero:** intentionally left as-is. `steps` is always a clean multiple of `steps_per_click` at rest, so the asymmetry can't manifest with real detents, and changing the rounding would alter public `getPosition()` semantics.

## Test seam + coverage

The decode/event engine was previously untestable because pins are read directly via `digitalRead()`. Added `setPinReadFunction()` (defaults to `digitalRead`, mirroring Button2's `setButtonStateFunction()`), so tests can drive a simulated quadrature signal.

**36 tests total** across three native suites (PlatformIO + EpoxyDuino + AUnit):
- `test_rotation` (19) — rotation/direction/multi-detent, per-detent callbacks, upper & lower bound clamp + overflow handlers, `triggerOnBounds(false)`, `retriggerEvent(false)`, `getLastEvent()`, `resetPosition(fireCallback)`, speedup engage/end (`isInSpeedup`, start/end handlers), speedup non-reversal guard, and regression tests for #2/#3/#5
- `test_core` (14) — position, bounds, increment/steps-per-click, direction, speedup config, IDs
- `test_context` (3) — `setContext`/`getContext`

## Verification

- `pio test -e test_rotation` → 19 passed
- `pio test -e test_core` → 14 passed
- `pio test -e test_context` → 3 passed
- `arduino-cli compile` of `examples/SimpleCounter` and `examples/RangedCounter` on ESP8266 D1 — clean

Version bumped to **2.2.1**.

https://claude.ai/code/session_01D43Q16eWAx25uiUC8wArBi